### PR TITLE
CORE-1495: Customise the connector persisting records on S3 in JSON format

### DIFF
--- a/s3/pom.xml
+++ b/s3/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>guava</artifactId>
             <version>29.0-jre</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/AwsConnectorStringFormats.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/AwsConnectorStringFormats.java
@@ -6,11 +6,13 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.regex.Pattern;
 
 public class AwsConnectorStringFormats {
-    public static final Pattern S3_OBJECT_KEY_PATTERN = Pattern.compile("^.*?([^/]+)/([0-9]+)/([0-9]+)-([0-9]+)$");
+    public static final String FILE_EXTENSION = ".txt";
+    public static final Pattern S3_OBJECT_KEY_PATTERN = Pattern.compile("^.*?([^/]+)/([0-9]+)/([0-9]+)-([0-9]+)" + FILE_EXTENSION + "$");
     public static final String S3_OBJECT_KEY_FORMAT = "%s%s/%d/%s-%s"; //prefix,topic,partition,%019d start offset, %019d end offset
     public static final String AWS_S3_DELIMITER = "/";
 
-    private AwsConnectorStringFormats(){}
+    private AwsConnectorStringFormats() {
+    }
 
     public static String parseS3Prefix(String value) {
         String prefix = "";
@@ -23,7 +25,7 @@ public class AwsConnectorStringFormats {
         return prefix;
     }
 
-    public static String convertLongIntoLexySortableString(long value){
+    public static String convertLongIntoLexySortableString(long value) {
         return String.format("%019d", value);
     }
 
@@ -36,7 +38,7 @@ public class AwsConnectorStringFormats {
                 AwsConnectorStringFormats.convertLongIntoLexySortableString(topicPartitionBuffer.getEndOffset()));
     }
 
-    public static String generateTargetTopic(String topicPrefix, String topic){
+    public static String generateTargetTopic(String topicPrefix, String topic) {
         return String.format("%s%s", (StringUtils.isBlank(topicPrefix) ? "" : topicPrefix + "-"), topic);
     }
 }

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/Record.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/Record.java
@@ -1,0 +1,15 @@
+package com.instaclustr.kafka.connect.s3;
+
+public class Record {
+    private final String k;
+    private final String v;
+    private final Long t;
+    private final long o;
+
+    Record(String k, String v, Long t, long o){
+        this.k = k;
+        this.v = v;
+        this.t = t;
+        this.o = o;
+    }
+}

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/RecordFormat.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/RecordFormat.java
@@ -7,6 +7,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 
 /**
@@ -18,6 +19,6 @@ public interface RecordFormat {
     // Throws a MaxBufferSizeExceededException if the record will be larger than the given sizeLimit
     int writeRecord(final DataOutputStream dataOutputStream, SinkRecord record, int sizeLimit) throws MaxBufferSizeExceededException, IOException;
 
-    SourceRecord readRecord(final DataInputStream dataInputStream, final Map<String, ?> sourcePartition, final Map<String, Object> sourceOffset, final String topic, final int partition) throws IOException;
+    SourceRecord readRecord(final String singleRow, final Map<String, ?> sourcePartition, final Map<String, Object> sourceOffset, final String topic, final int partition) throws IOException;
 
 }

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/sink/AwsStorageSinkWriter.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/sink/AwsStorageSinkWriter.java
@@ -14,18 +14,21 @@ public class AwsStorageSinkWriter {
     private TransferManager transferManager;
     private String bucketName;
     private String keyPrefix;
+    private String fileExtension;
 
     public AwsStorageSinkWriter(final TransferManager transferManager, final String bucket, final String keyPrefix) {
         this.transferManager = transferManager;
         this.bucketName = bucket;
         this.keyPrefix = AwsConnectorStringFormats.parseS3Prefix(keyPrefix);
+        this.fileExtension = AwsConnectorStringFormats.FILE_EXTENSION;
     }
 
     public void writeDataSegment(final TopicPartitionBuffer topicPartitionBuffer) throws IOException, InterruptedException {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(topicPartitionBuffer.getInputStreamLength());
+        String storageName = AwsConnectorStringFormats.topicPartitionBufferStorageName(keyPrefix, topicPartitionBuffer);
         PutObjectRequest request = new PutObjectRequest(bucketName
-                , AwsConnectorStringFormats.topicPartitionBufferStorageName(keyPrefix, topicPartitionBuffer)
+                , storageName + fileExtension
                 , topicPartitionBuffer.getInputStream()
                 , metadata);
         Upload upload = transferManager.upload(request);

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/sink/TopicPartitionBuffer.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/sink/TopicPartitionBuffer.java
@@ -10,8 +10,9 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 
 /**
- *  The fixed capacity buffer used to store SinkRecords given to the sink tasks from kafka connect.
- *  The SinkRecords will be encoded into bytes according to the recordFormat specified.
+ * The fixed capacity buffer used to store SinkRecords given to the sink tasks from kafka connect.
+ * The SinkRecords are constructed as json values which are then encoded into bytes.
+ * Each json record is followed by the '\n' character.
  */
 
 public class TopicPartitionBuffer {
@@ -32,7 +33,7 @@ public class TopicPartitionBuffer {
     }
 
     public TopicPartitionBuffer(final String topic, final int partition) throws IOException {
-        this(topic, partition, 5 * 1024 * 1024); // default max is 5mb
+        this(topic, partition, 3 * 1024 * 1024); // default max is 3MB
     }
 
     public TopicPartitionBuffer(final String topic, final int partition, int maxSizeBytes) throws IOException {
@@ -52,10 +53,8 @@ public class TopicPartitionBuffer {
             throw new RecordOutOfOrderException("Record offset must always be larger than the buffer latest record offset");
         }
 
-        if (currentPosition == 0) {
+        if (startOffset == -1) {
             startOffset = record.kafkaOffset();
-            dataStream.writeInt(0); // Version specifier
-            currentPosition += Integer.BYTES;
         }
 
         currentPosition += recordFormat.writeRecord(dataStream, record, capacity - currentPosition);
@@ -72,7 +71,7 @@ public class TopicPartitionBuffer {
         return pipedInputStream;
     }
 
-    public void cleanResources(){
+    public void cleanResources() {
         try {
             this.dataStream.close();
             this.pipedInputStream.close();

--- a/s3/src/main/java/com/instaclustr/kafka/connect/s3/source/AwsStorageSourceTask.java
+++ b/s3/src/main/java/com/instaclustr/kafka/connect/s3/source/AwsStorageSourceTask.java
@@ -113,7 +113,7 @@ public class AwsStorageSourceTask extends SourceTask {
                     SourceRecord record = topicPartitionSegmentParser.getNextRecord(10L, TimeUnit.SECONDS);
                     if (record != null) {
                         long recordOffset = (Long) record.sourceOffset().get("lastReadOffset");
-                        if (lastReadOffset == recordOffset - 1 || lastReadOffset == -1) {
+                        if (lastReadOffset <= recordOffset - 1) {
                             recordsToBeDelivered.add(record);
                             lastReadOffset = recordOffset;
                             awsSourceReader.setLastReadOffset(topicPartition, lastReadOffset);
@@ -122,13 +122,6 @@ public class AwsStorageSourceTask extends SourceTask {
                             log.warn("Lower offset encountered when reading data. " +
                                     "Record Offset :  {}, " +
                                     "last submitted offset {}", recordOffset, lastReadOffset);
-                        } else {
-                            log.error("Found record that is not next offset while parsing {}," +
-                                            " last committed record offset : {}," +
-                                            " current record offset : {} ",
-                                    record.sourceOffset().get("s3ObjectKey"), lastReadOffset, recordOffset);
-                            throw new MissingRecordsException(String.format("Last successful committed record offset : %d , next record offset : %d",
-                                    lastReadOffset, recordOffset));
                         }
                         notComplete = recordOffset != topicPartitionSegmentParser.getEndOffset();
                     } else {

--- a/s3/src/test/java/com/instaclustr/kafka/connect/s3/RecordFormat0Test.java
+++ b/s3/src/test/java/com/instaclustr/kafka/connect/s3/RecordFormat0Test.java
@@ -3,19 +3,12 @@ package com.instaclustr.kafka.connect.s3;
 import com.instaclustr.kafka.connect.s3.sink.MaxBufferSizeExceededException;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.header.ConnectHeaders;
-import org.apache.kafka.connect.header.Header;
-import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.source.SourceRecord;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 public class RecordFormat0Test {
 
@@ -31,31 +24,36 @@ public class RecordFormat0Test {
     }
 
     @Test
-    public void writeRecordNoHeaderTest() throws IOException, MaxBufferSizeExceededException {
-        SinkRecord toWrite = new SinkRecord("blah", 0, Schema.BYTES_SCHEMA, new byte[]{1,2,3}, Schema.BYTES_SCHEMA, new byte[]{4,5,6,7}, 5, 17L, TimestampType.NO_TIMESTAMP_TYPE);
+    public void writeRecordTest() throws IOException, MaxBufferSizeExceededException {
+        byte[] key = "\"1\"".getBytes();
+        byte[] value = "\"2\"".getBytes();
 
-        int written = recordFormat.writeRecord(dataOutputStream, toWrite, 35);
+        SinkRecord toWrite = new SinkRecord("test_topic", 0, Schema.STRING_SCHEMA, key, Schema.STRING_SCHEMA, value, 5, 17L, TimestampType.NO_TIMESTAMP_TYPE);
 
+        int written = recordFormat.writeRecord(dataOutputStream, toWrite, 39);
         byte[] output = bos.toByteArray();
 
         Assert.assertEquals(output.length, written);
-        Assert.assertEquals(output, new byte[]{
-                0, 0, 0, 0, 0, 0, 0, 5 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 17 // timestamp
-                , 0, 0, 0, 3 // key length
-                , 0, 0, 0, 4 // value length
-                , 0, 0, 0, 0 // header size
-                , 1, 2, 3 // key
-                , 4, 5, 6, 7 // value
-        });
+
+        byte[] expectedRecord = new byte[]{'{'
+                , '"', 'k', '"', ':', '"', '\\', '"', '1', '\\', '"', '"', ','
+                , '"', 'v', '"', ':', '"', '\\', '"', '2', '\\', '"', '"', ','
+                , '"', 't', '"', ':', '1', '7', ','
+                , '"', 'o', '"', ':', '5'
+                , '}'
+                , '\n'
+        };
+        Assert.assertEquals(output, expectedRecord);
     }
 
     @Test
     public void tooLargeTest() throws IOException {
-        SinkRecord toWrite = new SinkRecord("blah", 0, Schema.BYTES_SCHEMA, new byte[]{1,2,3}, Schema.BYTES_SCHEMA, new byte[]{4,5,6,7}, 5, 17L, TimestampType.NO_TIMESTAMP_TYPE);
+        byte[] key = new byte[]{1, 2, 3};
+        byte[] value = new byte[]{4, 5, 6, 7};
+        SinkRecord toWrite = new SinkRecord("test_topic", 0, Schema.STRING_SCHEMA, key, Schema.STRING_SCHEMA, value, 5, 17L, TimestampType.NO_TIMESTAMP_TYPE);
 
-        try{
-            recordFormat.writeRecord(dataOutputStream, toWrite, 34);
+        try {
+            recordFormat.writeRecord(dataOutputStream, toWrite, 11);
             Assert.fail("expected exception");
         } catch (MaxBufferSizeExceededException ex) {
             //expected exception
@@ -64,75 +62,30 @@ public class RecordFormat0Test {
 
     @Test
     public void writeEmptiesTest() throws IOException, MaxBufferSizeExceededException {
-        SinkRecord toWrite = new SinkRecord("blah", 0, Schema.BYTES_SCHEMA, new byte[0], Schema.BYTES_SCHEMA, new byte[0], 5, 17L, TimestampType.NO_TIMESTAMP_TYPE);
+        byte[] key = "".getBytes();
+        byte[] value = "".getBytes();
+        SinkRecord toWrite = new SinkRecord("test_topic", 0, Schema.STRING_SCHEMA, key, Schema.STRING_SCHEMA, value, 5, 17L, TimestampType.NO_TIMESTAMP_TYPE);
 
-        int written = recordFormat.writeRecord(dataOutputStream, toWrite, 35);
+        int written = recordFormat.writeRecord(dataOutputStream, toWrite, 33);
 
         byte[] output = bos.toByteArray();
-
         Assert.assertEquals(output.length, written);
-        Assert.assertEquals(output, new byte[]{
-                0, 0, 0, 0, 0, 0, 0, 5 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 17 // timestamp
-                , 0, 0, 0, 0 // key length
-                , 0, 0, 0, 0 // value length
-                , 0, 0, 0, 0 // header size
-        });
+
+        byte[] expectedRecord = "{\"k\":null,\"v\":null,\"t\":17,\"o\":5}\n".getBytes();
+        Assert.assertEquals(output, expectedRecord);
     }
 
     @Test
     public void writeNullsTest() throws IOException, MaxBufferSizeExceededException {
-        SinkRecord toWrite = new SinkRecord("blah", 0, Schema.BYTES_SCHEMA, null, Schema.BYTES_SCHEMA, null, 4, 16L, TimestampType.NO_TIMESTAMP_TYPE);
+        SinkRecord toWrite = new SinkRecord("test_topic", 0, Schema.STRING_SCHEMA, null, Schema.STRING_SCHEMA, null, 4, 16L, TimestampType.NO_TIMESTAMP_TYPE);
 
-        int written = recordFormat.writeRecord(dataOutputStream, toWrite, 35);
+        int written = recordFormat.writeRecord(dataOutputStream, toWrite, 33);
 
         byte[] output = bos.toByteArray();
 
         Assert.assertEquals(output.length, written);
-        Assert.assertEquals(output, new byte[]{
-                0, 0, 0, 0, 0, 0, 0, 4 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 16 // timestamp
-                , -1, -1, -1, -1 // key length
-                , -1, -1, -1, -1 // value length
-                , 0, 0, 0, 0 // header size
-        });
+
+        byte[] expectedRecord = "{\"k\":null,\"v\":null,\"t\":16,\"o\":4}\n".getBytes();
+        Assert.assertEquals(output, expectedRecord);
     }
-
-    @Test
-    public void readWriteWithHeadersTest() throws IOException, MaxBufferSizeExceededException {
-        Headers headers = new ConnectHeaders();
-        headers.addString("a", "asdas");
-        headers.addString("b", "");
-        headers.add("cc", null, null);
-        List<Header> inHeaders = new ArrayList<>();
-        for (Header h : headers) {
-            inHeaders.add(h);
-        }
-
-        SinkRecord toWrite = new SinkRecord("blah", 0, Schema.BYTES_SCHEMA, new byte[]{1,2,3}, Schema.BYTES_SCHEMA, new byte[]{4,5,6,7}, 5, 17L, TimestampType.NO_TIMESTAMP_TYPE, headers);
-        recordFormat.writeRecord(dataOutputStream, toWrite, 100);
-
-        byte[] output = bos.toByteArray();
-        DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(output));
-
-        HashMap<String, Object> sourcePartition = new HashMap<>();
-        sourcePartition.put("QQ", "WW");
-
-        HashMap<String, Object> sourceOffsets = new HashMap<>();
-        sourceOffsets.put("AA", "SS");
-
-        SourceRecord sourceRecord = recordFormat.readRecord(dataInputStream, sourcePartition, sourceOffsets, "topic", 1);
-
-        Assert.assertEquals(sourceRecord.sourceOffset().get("AA"), "SS");
-        Assert.assertEquals(sourceRecord.sourcePartition().get("QQ"), "WW");
-        Assert.assertEquals(sourceRecord.key(), new byte[]{1,2,3});
-        Assert.assertEquals(sourceRecord.value(), new byte[]{4,5,6,7});
-        List<Header> outHeaders = new ArrayList<>();
-        for (Header h : sourceRecord.headers()) {
-            outHeaders.add(h);
-        }
-        Assert.assertEquals(outHeaders, inHeaders);
-
-    }
-
 }

--- a/s3/src/test/java/com/instaclustr/kafka/connect/s3/sink/TopicPartitionBufferTest.java
+++ b/s3/src/test/java/com/instaclustr/kafka/connect/s3/sink/TopicPartitionBufferTest.java
@@ -3,52 +3,47 @@ package com.instaclustr.kafka.connect.s3.sink;
 
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.header.ConnectHeaders;
-import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-
+import java.io.*;
 
 public class TopicPartitionBufferTest {
 
     public static final String TOPIC = "topic";
-    public static final String KEY_STRING = "key";
-    public static final String VALUE_STRING = "value";
+    public static final String KEY_JSON = "{\"x\":\"11\"}";
+    public static final String VALUE_JSON = "{\"y\":\"22\"}";
 
     @Test
     public void noSpaceForVersionInformation() throws IOException, RecordOutOfOrderException {
-        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 36);
-        byte[] key = KEY_STRING.getBytes();
-        byte[] value = VALUE_STRING.getBytes();
+        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 14);
+        byte[] key = KEY_JSON.getBytes();
+        byte[] value = VALUE_JSON.getBytes();
         SinkRecord record = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
 
         try {
             topicPartitionBuffer.putRecord(record);
             Assert.fail("Exception expected");
-        }
-        catch (MaxBufferSizeExceededException ex) {
+        } catch (MaxBufferSizeExceededException ex) {
             // Expected
         }
     }
 
     @Test
     public void putRecordOnce() throws IOException, RecordOutOfOrderException, MaxBufferSizeExceededException {
-        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 40);
-        byte[] key = KEY_STRING.getBytes();
-        byte[] value = VALUE_STRING.getBytes();
+        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 57);
+        byte[] key = KEY_JSON.getBytes();
+        byte[] value = VALUE_JSON.getBytes();
         SinkRecord record = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
 
-        byte[] expected = new byte[]{0, 0, 0, 0 // version
-                , 0, 0, 0, 0, 0, 0, 0, 2 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 64 // timestamp
-                , 0, 0, 0, 3 // key length
-                , 0, 0, 0, 5 // value length
-                , 0, 0, 0, 0 //header count
-                , 'k', 'e', 'y'
-                , 'v', 'a', 'l', 'u', 'e'
+        byte[] expected = new byte[]{'{'
+                , '"', 'k', '"', ':', '"', '{', '\\', '"', 'x', '\\', '"', ':', '\\', '"', '1', '1', '\\', '"', '}', '"', ','
+                , '"', 'v', '"', ':', '"', '{', '\\', '"', 'y', '\\', '"', ':', '\\', '"', '2', '2', '\\', '"', '}', '"', ','
+                , '"', 't', '"', ':', '6', '4', ','
+                , '"', 'o', '"', ':', '2'
+                , '}'
+                , '\n'
         };
 
         topicPartitionBuffer.putRecord(record);
@@ -59,66 +54,63 @@ public class TopicPartitionBufferTest {
 
     @Test
     public void putRecordTwice() throws IOException, RecordOutOfOrderException, MaxBufferSizeExceededException {
-        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 76);
-        byte[] key = KEY_STRING.getBytes();
-        byte[] value = VALUE_STRING.getBytes();
-        SinkRecord record = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
+        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 114);
+        byte[] key = KEY_JSON.getBytes();
+        byte[] value = VALUE_JSON.getBytes();
+        SinkRecord record1 = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
         SinkRecord record2 = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 3, 68L, TimestampType.NO_TIMESTAMP_TYPE);
 
-        byte[] expected = new byte[]{0, 0, 0, 0 // version
-                , 0, 0, 0, 0, 0, 0, 0, 2 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 64 // timestamp
-                , 0, 0, 0, 3 // key length
-                , 0, 0, 0, 5 // value length
-                , 0, 0, 0, 0 //header length
-                , 'k', 'e', 'y'
-                , 'v', 'a', 'l', 'u', 'e'
-                , 0, 0, 0, 0, 0, 0, 0, 3 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 68 // timestamp
-                , 0, 0, 0, 3 // key length
-                , 0, 0, 0, 5 // value length
-                , 0, 0, 0, 0 //header length
-                , 'k', 'e', 'y'
-                , 'v', 'a', 'l', 'u', 'e'
+        byte[] expected = new byte[]{'{'
+                , '"', 'k', '"', ':', '"', '{', '\\', '"', 'x', '\\', '"', ':', '\\', '"', '1', '1', '\\', '"', '}', '"', ','
+                , '"', 'v', '"', ':', '"', '{', '\\', '"', 'y', '\\', '"', ':', '\\', '"', '2', '2', '\\', '"', '}', '"', ','
+                , '"', 't', '"', ':', '6', '4', ','
+                , '"', 'o', '"', ':', '2'
+                , '}'
+                , '\n'
+                , '{'
+                , '"', 'k', '"', ':', '"', '{', '\\', '"', 'x', '\\', '"', ':', '\\', '"', '1', '1', '\\', '"', '}', '"', ','
+                , '"', 'v', '"', ':', '"', '{', '\\', '"', 'y', '\\', '"', ':', '\\', '"', '2', '2', '\\', '"', '}', '"', ','
+                , '"', 't', '"', ':', '6', '8', ','
+                , '"', 'o', '"', ':', '3'
+                , '}'
+                , '\n'
         };
 
-        topicPartitionBuffer.putRecord(record);
-        Assert.assertEquals(topicPartitionBuffer.getInputStreamLength(), 40);
+        topicPartitionBuffer.putRecord(record1);
+        Assert.assertEquals(topicPartitionBuffer.getInputStreamLength(), 57);
         topicPartitionBuffer.putRecord(record2);
         Assert.assertEquals(topicPartitionBuffer.getInputStreamLength(), expected.length);
         byte[] byteResult = topicPartitionBuffer.getInputStream().readNBytes(topicPartitionBuffer.getInputStreamLength());
         Assert.assertEquals(byteResult, expected);
-
     }
 
     @Test
     public void putRecordThrice() throws IOException, RecordOutOfOrderException, MaxBufferSizeExceededException {
-        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 76);
-        byte[] key = KEY_STRING.getBytes();
-        byte[] value = VALUE_STRING.getBytes();
-        SinkRecord record = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
+        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 114);
+        byte[] key = KEY_JSON.getBytes();
+        byte[] value = VALUE_JSON.getBytes();
+        SinkRecord record1 = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
         SinkRecord record2 = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 3, 68L, TimestampType.NO_TIMESTAMP_TYPE);
         SinkRecord record3 = new SinkRecord(TOPIC, 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 4, 72L, TimestampType.NO_TIMESTAMP_TYPE);
 
-        byte[] expected = new byte[]{0, 0, 0, 0 // version
-                , 0, 0, 0, 0, 0, 0, 0, 2 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 64 // timestamp
-                , 0, 0, 0, 3 // key length
-                , 0, 0, 0, 5 // value length
-                , 0, 0, 0, 0 //header length
-                , 'k', 'e', 'y'
-                , 'v', 'a', 'l', 'u', 'e'
-                , 0, 0, 0, 0, 0, 0, 0, 3 // offset
-                , 0, 0, 0, 0, 0, 0, 0, 68 // timestamp
-                , 0, 0, 0, 3 // key length
-                , 0, 0, 0, 5 // value length
-                , 0, 0, 0, 0 //header length
-                , 'k', 'e', 'y'
-                , 'v', 'a', 'l', 'u', 'e'
+        byte[] expected = new byte[]{'{'
+                , '"', 'k', '"', ':', '"', '{', '\\', '"', 'x', '\\', '"', ':', '\\', '"', '1', '1', '\\', '"', '}', '"', ','
+                , '"', 'v', '"', ':', '"', '{', '\\', '"', 'y', '\\', '"', ':', '\\', '"', '2', '2', '\\', '"', '}', '"', ','
+                , '"', 't', '"', ':', '6', '4', ','
+                , '"', 'o', '"', ':', '2'
+                , '}'
+                , '\n'
+                , '{'
+                , '"', 'k', '"', ':', '"', '{', '\\', '"', 'x', '\\', '"', ':', '\\', '"', '1', '1', '\\', '"', '}', '"', ','
+                , '"', 'v', '"', ':', '"', '{', '\\', '"', 'y', '\\', '"', ':', '\\', '"', '2', '2', '\\', '"', '}', '"', ','
+                , '"', 't', '"', ':', '6', '8', ','
+                , '"', 'o', '"', ':', '3'
+                , '}'
+                , '\n'
         };
 
-        topicPartitionBuffer.putRecord(record);
-        Assert.assertEquals(topicPartitionBuffer.getInputStreamLength(), 40);
+        topicPartitionBuffer.putRecord(record1);
+        Assert.assertEquals(topicPartitionBuffer.getInputStreamLength(), 57);
 
         topicPartitionBuffer.putRecord(record2);
         Assert.assertEquals(topicPartitionBuffer.getInputStreamLength(), expected.length);
@@ -133,42 +125,5 @@ public class TopicPartitionBufferTest {
 
         byte[] byteResult = topicPartitionBuffer.getInputStream().readNBytes(topicPartitionBuffer.getInputStreamLength());
         Assert.assertEquals(byteResult, expected);
-
     }
-
-    @Test
-    public void putRecordWithHeaderData() throws IOException, RecordOutOfOrderException, MaxBufferSizeExceededException {
-        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer(TOPIC, 0, 80);
-        Headers headers = new ConnectHeaders();
-        headers.addBytes("header", new byte[]{1,1});
-        headers.addBoolean("bool", true);
-        SinkRecord record = new SinkRecord(
-                TOPIC,
-                0,
-                Schema.OPTIONAL_BYTES_SCHEMA,
-                new byte[]{1,2,3},
-                Schema.OPTIONAL_BYTES_SCHEMA,
-                new byte[]{0,0,0},
-                2,
-                64L,
-                TimestampType.NO_TIMESTAMP_TYPE,
-                headers);
-        byte[] expected = new byte[]{
-                0, 0, 0, 0, //version
-                0, 0, 0, 0, 0, 0, 0, 2, //offset
-                0, 0, 0, 0, 0, 0, 0, 64, //timestamp
-                0, 0, 0, 3, //key length
-                0, 0, 0, 3, //value length
-                0, 0, 0, 2, //header length
-                1, 2, 3, //key
-                0, 0, 0, //value
-                0, 0, 0, 6, 104, 101, 97, 100, 101, 114, //header1 key length and value
-                0, 0, 0, 4, 65, 81, 69, 61, //header1 value length and data
-                0, 0, 0, 4, 98, 111, 111, 108,
-                0, 0, 0, 4, 116, 114, 117, 101
-        };
-        topicPartitionBuffer.putRecord(record);
-        Assert.assertEquals(topicPartitionBuffer.getInputStream().readNBytes(topicPartitionBuffer.getInputStreamLength()), expected);
-    }
-
 }

--- a/s3/src/test/java/com/instaclustr/kafka/connect/s3/source/AwsStorageSourceTaskTest.java
+++ b/s3/src/test/java/com/instaclustr/kafka/connect/s3/source/AwsStorageSourceTaskTest.java
@@ -4,7 +4,6 @@ package com.instaclustr.kafka.connect.s3.source;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.instaclustr.kafka.connect.s3.TransferManagerProvider;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -14,7 +13,6 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -98,32 +96,12 @@ public class AwsStorageSourceTaskTest {
     }
 
     @Test
-    public void givenObjectStreamThatGivesBadOffsetRecordThrowException() throws Exception {
-        TransferManagerProvider mockTransferManagerProvider = mock(TransferManagerProvider.class);
-        AwsSourceReader mockAwsSourceReader = mock(AwsSourceReader.class);
-        TopicPartitionSegmentParser mockTopicPartitionSegmentParser = mock(TopicPartitionSegmentParser.class);
-
-        doReturn(mockTopicPartitionSegmentParser).when(mockAwsSourceReader).getNextTopicPartitionSegmentParser();
-        doReturn("test").when(mockTopicPartitionSegmentParser).getTopic();
-        doReturn(0).when(mockTopicPartitionSegmentParser).getPartition();
-        doReturn(1L).when(mockAwsSourceReader).getLastReadOffset(any());
-        HashMap<String, Object> sourceOffset = new HashMap<>();
-        sourceOffset.put("lastReadOffset", 5L);
-        sourceOffset.put("s3ObjectKey", "test-key");
-
-        doReturn(new SourceRecord(Collections.emptyMap(), sourceOffset, "test", 0, Schema.BYTES_SCHEMA, new byte[0])).when(mockTopicPartitionSegmentParser).getNextRecord(any(), any());
-
-        AwsStorageSourceTask awsStorageSourceTask = new AwsStorageSourceTask(mockTransferManagerProvider, mockAwsSourceReader);
-        Assert.expectThrows(MissingRecordsException.class, awsStorageSourceTask::poll);
-    }
-
-    @Test
     public void givenAwsSdkThrowsServiceTypeAwsServerExceptionResetReadPosition() throws IOException {
         TransferManagerProvider mockTransferManagerProvider = mock(TransferManagerProvider.class);
         AwsSourceReader mockAwsSourceReader = mock(AwsSourceReader.class);
         S3ObjectInputStream s3ObjectInputStream = mock(S3ObjectInputStream.class);
         TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(s3ObjectInputStream,
-                "prefix/test/0/0000000000000000002-0000000000000000004", "");
+                "prefix/test/0/0000000000000000002-0000000000000000004.txt", "");
 
         doReturn(topicPartitionSegmentParser).when(mockAwsSourceReader).getNextTopicPartitionSegmentParser();
         AmazonServiceException amazonServiceException = new AmazonServiceException("hello");
@@ -141,7 +119,7 @@ public class AwsStorageSourceTaskTest {
         AwsSourceReader mockAwsSourceReader = mock(AwsSourceReader.class);
         S3ObjectInputStream s3ObjectInputStream = mock(S3ObjectInputStream.class);
         TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(s3ObjectInputStream,
-                "prefix/test/0/0000000000000000002-0000000000000000004", "");
+                "prefix/test/0/0000000000000000002-0000000000000000004.txt", "");
 
         doReturn(topicPartitionSegmentParser).when(mockAwsSourceReader).getNextTopicPartitionSegmentParser();
         AmazonClientException amazonClientException = new AmazonClientException("hello");

--- a/s3/src/test/java/com/instaclustr/kafka/connect/s3/source/TopicPartitionSegmentParserTest.java
+++ b/s3/src/test/java/com/instaclustr/kafka/connect/s3/source/TopicPartitionSegmentParserTest.java
@@ -1,12 +1,8 @@
 package com.instaclustr.kafka.connect.s3.source;
 
-import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.instaclustr.kafka.connect.s3.sink.TopicPartitionBuffer;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.apache.kafka.connect.header.ConnectHeaders;
-import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.testng.Assert;
@@ -15,88 +11,134 @@ import org.testng.annotations.Test;
 import java.io.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 
 public class TopicPartitionSegmentParserTest {
     public static final String LAST_READ_OFFSET = "lastReadOffset";
-    String s3ObjectKey = "prefix/test/0/0000000000000000002-0000000000000000004";
+    String s3ObjectKey = "prefix/test/0/0000000000000000002-0000000000000000004.txt";
 
     @Test
-    public void givenWellFormulatedDataRetrieveCorrectInformation() throws Exception {
+    public void serDesIsWorkingForWeirdCharacters() throws Exception{
         TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer("test", 0);
-        byte[] key = "key".getBytes();
-        byte[] value = "value".getBytes();
-        Headers connectHeaders = new ConnectHeaders();
-        connectHeaders.addBoolean("bool", true);
-        connectHeaders.addString("string", "Hello There! Some special chars : @#@!#åˆ¨˜˜™ªºææ¬˚∆ªºææ≥≤˜˜∆åß");
-        connectHeaders.add("fv", SchemaAndValue.NULL);
-        connectHeaders.addInt("int", 1231321313);
+        byte[] key = "\"££:::::£`£\"".getBytes();
+        byte[] value = "\"\n&\t&&&$مُنَاقَشَةُ سُبُلِ اِسَّْطْبِيقَاتُ الْحاسُوبِيَّة\"".getBytes();
 
-        SinkRecord record = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, null, Schema.OPTIONAL_BYTES_SCHEMA, null, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
-        SinkRecord record2 = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, "".getBytes(), Schema.OPTIONAL_BYTES_SCHEMA, "".getBytes(), 3, 68L, TimestampType.NO_TIMESTAMP_TYPE, null);
-        SinkRecord record3 = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 4, 72L, TimestampType.NO_TIMESTAMP_TYPE, connectHeaders);
+        SinkRecord record = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
         topicPartitionBuffer.putRecord(record);
+
+        InputStream dataInputStream = topicPartitionBuffer.getInputStream();
+        TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(dataInputStream, s3ObjectKey, "");
+
+        Assert.assertEquals(topicPartitionBuffer.topic, "test");
+        Assert.assertEquals(topicPartitionBuffer.partition, 0);
+        Assert.assertEquals(topicPartitionBuffer.getEndOffset(), 2L);
+        Assert.assertEquals(topicPartitionBuffer.getStartOffset(), 2L);
+
+        SourceRecord sourceRecord = topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
+        Assert.assertEquals(sourceRecord.sourceOffset().get(LAST_READ_OFFSET), 2L);
+        Assert.assertEquals((byte[]) sourceRecord.key(), key);
+        Assert.assertEquals((byte[]) sourceRecord.value(), value);
+        Assert.assertEquals(sourceRecord.timestamp(), record.timestamp());
+    }
+
+    @Test
+    public void givenKeyAsJSValue() throws Exception {
+        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer("test", 0);
+        byte[] key = "\"hFCBaHIxQh\"".getBytes();
+        byte[] value = "{\"y\":\"22\"}".getBytes();
+
+        SinkRecord record = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
+        topicPartitionBuffer.putRecord(record);
+
+        InputStream dataInputStream = topicPartitionBuffer.getInputStream();
+        TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(dataInputStream, s3ObjectKey, "");
+
+        Assert.assertEquals(topicPartitionBuffer.topic, "test");
+        Assert.assertEquals(topicPartitionBuffer.partition, 0);
+        Assert.assertEquals(topicPartitionBuffer.getEndOffset(), 2L);
+        Assert.assertEquals(topicPartitionBuffer.getStartOffset(), 2L);
+
+        SourceRecord sourceRecord = topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
+        Assert.assertEquals(sourceRecord.sourceOffset().get(LAST_READ_OFFSET), 2L);
+        Assert.assertEquals((byte[]) sourceRecord.key(), key);
+        Assert.assertEquals((byte[]) sourceRecord.value(), value);
+        Assert.assertEquals(sourceRecord.timestamp(), record.timestamp());
+    }
+
+    @Test
+    public void givenWellFormulatedLargeDataSingleRecord() throws Exception {
+        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer("test", 0);
+        byte[] key = "{\"x\":\"epuWQMjIgP\"}".getBytes();
+        byte[] value = "{\"y\":\"22\"}".getBytes();
+
+        SinkRecord record = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
+        topicPartitionBuffer.putRecord(record);
+
+        InputStream dataInputStream = topicPartitionBuffer.getInputStream();
+        TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(dataInputStream, s3ObjectKey, "");
+
+        Assert.assertEquals(topicPartitionBuffer.topic, "test");
+        Assert.assertEquals(topicPartitionBuffer.partition, 0);
+        Assert.assertEquals(topicPartitionBuffer.getEndOffset(), 2L);
+        Assert.assertEquals(topicPartitionBuffer.getStartOffset(), 2L);
+
+        SourceRecord sourceRecord = topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
+        Assert.assertEquals(sourceRecord.sourceOffset().get(LAST_READ_OFFSET), 2L);
+        Assert.assertEquals((byte[]) sourceRecord.key(), key);
+        Assert.assertEquals((byte[]) sourceRecord.value(), value);
+        Assert.assertEquals(sourceRecord.timestamp(), record.timestamp());
+    }
+
+    @Test
+    public void givenWellFormulatedDataMultipleRecords() throws Exception {
+        TopicPartitionBuffer topicPartitionBuffer = new TopicPartitionBuffer("test", 0);
+        byte[] key = "{\"x\":\"11\"}".getBytes();
+        byte[] value = "{\"y\":\"22\"}".getBytes();
+
+        SinkRecord record1 = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, null, Schema.OPTIONAL_BYTES_SCHEMA, null, 2, 64L, TimestampType.NO_TIMESTAMP_TYPE);
+        SinkRecord record2 = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, "".getBytes(), Schema.OPTIONAL_BYTES_SCHEMA, "".getBytes(), 3, 68L, TimestampType.NO_TIMESTAMP_TYPE, null);
+        SinkRecord record3 = new SinkRecord("test", 0, Schema.OPTIONAL_BYTES_SCHEMA, key, Schema.OPTIONAL_BYTES_SCHEMA, value, 4, 72L, TimestampType.NO_TIMESTAMP_TYPE);
+        topicPartitionBuffer.putRecord(record1);
         topicPartitionBuffer.putRecord(record2);
         topicPartitionBuffer.putRecord(record3);
         InputStream dataInputStream = topicPartitionBuffer.getInputStream();
         TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(dataInputStream, s3ObjectKey, "");
+
         Assert.assertEquals(topicPartitionBuffer.topic, "test");
         Assert.assertEquals(topicPartitionBuffer.partition, 0);
         Assert.assertEquals(topicPartitionBuffer.getEndOffset(), 4L);
         Assert.assertEquals(topicPartitionBuffer.getStartOffset(), 2L);
 
-        SourceRecord firstRecord = topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
-        Assert.assertEquals(firstRecord.sourceOffset().get(LAST_READ_OFFSET), 2L);
-        Assert.assertNull(firstRecord.key());
-        Assert.assertNull(firstRecord.value());
-        Assert.assertEquals(firstRecord.timestamp(), record.timestamp());
-        Assert.assertEquals(firstRecord.headers().size(), 0);
+        SourceRecord firstSourceRecord = topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
+        Assert.assertEquals(firstSourceRecord.sourceOffset().get(LAST_READ_OFFSET), 2L);
+        Assert.assertNull(firstSourceRecord.key());
+        Assert.assertNull(firstSourceRecord.value());
+        Assert.assertEquals(firstSourceRecord.timestamp(), record1.timestamp());
 
-        SourceRecord secondRecord = topicPartitionSegmentParser.getNextRecord(5L, TimeUnit.SECONDS);
-        Assert.assertEquals(secondRecord.sourceOffset().get(LAST_READ_OFFSET), 3L);
-        Assert.assertEquals(secondRecord.key(), "".getBytes());
-        Assert.assertEquals(secondRecord.headers().size(), 0);
-        Assert.assertEquals(secondRecord.timestamp(), record2.timestamp());
-        Assert.assertEquals(new String((byte[]) secondRecord.value()), "");
 
-        SourceRecord thirdRecord = topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
-        Assert.assertEquals(thirdRecord.sourceOffset().get(LAST_READ_OFFSET), 4L);
-        Assert.assertEquals((byte[]) thirdRecord.key(), key);
-        Assert.assertEquals((byte[]) thirdRecord.value(), value);
-        Assert.assertEquals(thirdRecord.timestamp(), record3.timestamp());
-        Assert.assertEquals(thirdRecord.headers(), connectHeaders);
+        SourceRecord secondSourceRecord = topicPartitionSegmentParser.getNextRecord(5L, TimeUnit.SECONDS);
+        Assert.assertEquals(secondSourceRecord.sourceOffset().get(LAST_READ_OFFSET), 3L);
+        Assert.assertNull(firstSourceRecord.key());
+        Assert.assertNull(firstSourceRecord.value());
+        Assert.assertEquals(secondSourceRecord.timestamp(), record2.timestamp());
+
+
+        SourceRecord thirdSourceRecord = topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
+        Assert.assertEquals(thirdSourceRecord.sourceOffset().get(LAST_READ_OFFSET), 4L);
+        Assert.assertEquals((byte[]) thirdSourceRecord.key(), key);
+        Assert.assertEquals((byte[]) thirdSourceRecord.value(), value);
+        Assert.assertEquals(thirdSourceRecord.timestamp(), record3.timestamp());
     }
 
     @Test
-    public void givenNonResponsiveStreamTriggerTimeoutOnDefinedTimePeriod() throws IOException {
+    public void givenNonResponsiveStreamRaiseIoException() throws Exception {
         PipedOutputStream pipedOutputStream = null;
         try (PipedInputStream empty = new PipedInputStream(1)) {
             pipedOutputStream = new PipedOutputStream(empty); //making sure we just have an unresponsive stream and not throwing an ioexception
             TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(empty, s3ObjectKey, "");
-            Assert.expectThrows(TimeoutException.class, () -> topicPartitionSegmentParser.getNextRecord(5L, TimeUnit.MILLISECONDS));
-        } finally {
-            if (pipedOutputStream != null) {
-                pipedOutputStream.close();
-            }
-        }
-    }
-
-    @Test
-    public void returnNullOnEofException() throws Exception {
-        TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(InputStream.nullInputStream(), s3ObjectKey, "");
-        Assert.assertNull(topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS));
-        Assert.assertNull(topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS));
-        topicPartitionSegmentParser.closeResources();
-    }
-
-    @Test
-    public void multipleCreationOfParsersInALoop() throws Exception {
-        //test if there is a thread leak
-        for (int i = 0; i < 5000; i++) {
-            TopicPartitionSegmentParser topicPartitionSegmentParser = new TopicPartitionSegmentParser(InputStream.nullInputStream(), s3ObjectKey, "");
-            Assert.assertNull(topicPartitionSegmentParser.getNextRecord(100L, TimeUnit.MILLISECONDS));
-            topicPartitionSegmentParser.closeResources();
+            topicPartitionSegmentParser.getNextRecord(1L, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof ExecutionException);
+            Assert.assertTrue(e.getCause() instanceof IOException);
         }
     }
 


### PR DESCRIPTION
The significant change of this `kafka-connect-connector` is that records are now _serialised_ as Json and then encoded into bytes when they are published on S3. Records on S3 are delimited by the new line character, `\n`. 
When reading the data from S3, records are _decoded_ as String (using `UTF_8`) and then are parsed as Json in order to publish the key, value, timestamp and offset information in Kafka.

This PR also adds the following characteristics:

- File extension of the segment files on S3 now changes to `.txt`
- MaxBufferSize is now defaulted to 3MB. The `topic/partition/startOffset-endOffset.txt` segments are filled up to 3MB. When this threshold is met for a given range of start and end offset then we are ending up with 2 files having the same start offset but different end offset. E.g. 
`0000000000000000000-0000000000000000056.txt` and 
 `0000000000000000000-0000000000000000068.txt`
 - Given that we are not manipulating the kafka Headers, they are now removed. 
 - Supports non-consecutive offsets (I added this small change as part of my PR cause the branch with this change was 1 year old)